### PR TITLE
Fixes issue when two items are out of order.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,3 @@
-Array.prototype.stalinSort = function(cb) {
-  if(!cb) {
-    return this.filter((i, index) => (''+i)
-      .localeCompare(''+(index < this.length ? this[index + 1] : i)) < 0)
-  }
-  return this.filter((a, index) => {
-    const b = index < this.length ? this[index + 1] : index
-    return cb(a, b) < 0
-  })
+Array.prototype.stalinSort = function(cb=(a, b) => (a+'').localeCompare(b)) {
+  return this.slice(1).reduce((b, a) => b.concat(~cb(a, b[b.length-1]) ? [a] : []), this.slice(0, 1))
 }


### PR DESCRIPTION
Before:

```js
['a','c', 'd', 'b'].stalinSort()
// (3) ["a", "c", "b"]
```

After:
```js
['a','c', 'd', 'b'].stalinSort()

// (3) ["a", "c", "d"]
```